### PR TITLE
hydran-xyz-sonar-issues

### DIFF
--- a/src/main/java/se/sundsvall/digitalregisteredletter/integration/kivra/KivraMapper.java
+++ b/src/main/java/se/sundsvall/digitalregisteredletter/integration/kivra/KivraMapper.java
@@ -1,6 +1,7 @@
 package se.sundsvall.digitalregisteredletter.integration.kivra;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -48,7 +49,7 @@ public class KivraMapper {
 	 */
 	ContentUserV2.RegisteredLetter toRegisteredLetter(final String reference) {
 		return RegisteredLetterBuilder.create()
-			.withExpiresAt(OffsetDateTime.now().plusDays(30))
+			.withExpiresAt(OffsetDateTime.now(ZoneId.systemDefault()).plusDays(30))
 			.withSenderReference(new ContentUserV2.RegisteredLetter.SenderReference(reference))
 			.withHidden(createRegisteredLetterHidden())
 			.build();

--- a/src/main/java/se/sundsvall/digitalregisteredletter/service/scheduler/CertificateHealthScheduler.java
+++ b/src/main/java/se/sundsvall/digitalregisteredletter/service/scheduler/CertificateHealthScheduler.java
@@ -1,6 +1,7 @@
 package se.sundsvall.digitalregisteredletter.service.scheduler;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -100,7 +101,7 @@ public class CertificateHealthScheduler {
 	}
 
 	private void sendMail(final String recipient) {
-		final var time = LocalDateTime.now().truncatedTo(MINUTES);
+		final var time = LocalDateTime.now(ZoneId.systemDefault()).truncatedTo(MINUTES);
 
 		ofNullable(toEmailRequest(
 			recipient,


### PR DESCRIPTION
Fixes the open **java.time** SonarCloud issues in this service (`java:S8688` × 2).

> Explicitly specify the time zone by passing a ZoneId or a Clock to the `.now()` method.

Every no-arg `java.time` `.now()` call in `src/main` now passes `ZoneId.systemDefault()` explicitly, including statically imported bare `now()` calls. Behaviour unchanged, and this matches the convention already dominant across the fleet.

### Verification
`mvn clean verify` — all tests green, JaCoCo coverage gate passed.

### Note on the SonarCloud quality gate
This PR may trip `new_duplicated_lines_density`. The changed lines often sit inside `@PrePersist`/`@PreUpdate` timestamp boilerplate that is near-identical across entity classes, and a PR's denominator is only the changed lines — so a few lines inside pre-existing duplicated blocks can exceed the 3% threshold. No code defect and no behaviour change; needs a reviewer override.
